### PR TITLE
Update NEXT-RNAi.pl

### DIFF
--- a/NEXT-RNAi.pl
+++ b/NEXT-RNAi.pl
@@ -642,7 +642,7 @@ sub BowtieTarget {
 		    $inputsiRNA = $1.$2;
 		}
 # number of matches of complete input sequence to a certain sequence in the off-target database
-		if ((!defined %$TargetExclude) || (!exists $$TargetExclude{$columns[2]})){
+		if ((!%$TargetExclude) || (!exists $$TargetExclude{$columns[2]})){
 		    if (!exists $$InputTarget{$input}{$columns[2]}){
 			$$InputTarget{$input}{$columns[2]} = 1;
 		    }


### PR DESCRIPTION
Perl v5.6.1 deprecated the defined function, and it returns the message below. The defined function is omitted to fix the error.

Can't use 'defined(%hash)' (Maybe you should just omit the defined()?) at
	nextrnai/NEXT-RNAi.pl line 645 (#1)
    (F) defined() is not usually right on hashes.
    
    Although defined %hash is false on a plain not-yet-used hash, it
    becomes true in several non-obvious circumstances, including iterators,
    weak references, stash names, even remaining true after undef %hash.
    These things make defined %hash fairly useless in practice, so it now
    generates a fatal error.
    
    If a check for non-empty is what you wanted then just put it in boolean
    context (see "Scalar values" in perldata):
    
        if (%hash) {
           # not empty
        }
    
    If you had defined %Foo::Bar::QUUX to check whether such a package
    variable exists then that's never really been reliable, and isn't
    a good way to enquire about the features of a package, or whether
    it's loaded, etc.
    
Uncaught exception from user code:
	Can't use 'defined(%hash)' (Maybe you should just omit the defined()?) at nextrnai/NEXT-RNAi.pl line 645.